### PR TITLE
added captainkyds_scripz with a script to install an upgrade command

### DIFF
--- a/scripts/captainkyds_scripz/build&RunUpgradeCommand.txt
+++ b/scripts/captainkyds_scripz/build&RunUpgradeCommand.txt
@@ -1,24 +1,26 @@
-echo 'tput bold; tput setaf 5; echo "time to clean out old apt files and upgrade. Here we go"; tput sgr0' >> /usr/local/bin/upgrade
-echo 'tput bold; tput setaf 5; echo "Starting the cleaning cycle."; tput sgr0'  >> /usr/local/bin/upgrade
+echo "color='tput setaf 5; tput bold" >> /usr/local/bin/upgrade
+echo "reset=tput sgr0"  >> /usr/local/bin/upgrade
+echo '$(color); echo "time to clean out old apt files and upgrade. Here we go."; $(reset)' >> /usr/local/bin/upgrade
+echo '$(color) echo "Starting the cleaning cycle."; $(reset)'  >> /usr/local/bin/upgrade
 echo 'apt clean -y' >> /usr/local/bin/upgrade
 echo 'apt autoremove -y' >> /usr/local/bin/upgrade
-echo 'tput bold; tput setaf 5; echo "updating and upgrading your distro" tput sgr0'  >> /usr/local/bin/upgrade
+echo '$(color); echo "All done cleaning now updating sources and upgrading your distro"; $(reset)'  >> /usr/local/bin/upgrade
 echo 'apt update' >> /usr/local/bin/upgrade
-eco 'apt upgrade -y' >> /usr/local/bin/upgrade
+echo 'apt upgrade -y' >> /usr/local/bin/upgrade
 echo 'apt dist-upgrade -y' >> /usr/local/bin/upgrade
-echo 'tput bold; tput setaf 5; echo "the upgrade has been completed. Enjoy"; tput sgr0' >> /usr/local/bin/upgrade
+echo '$(color); echo "the upgrade has been completed. Enjoy"; $(reset)' >> /usr/local/bin/upgrade
 chmod +x /usr/local/bin/upgrade
 upgrade
 
 # this can now be run with "sudo upgrade" or added to your crontab via the command "sudo crontab -e"
 # select your favorite editor and at the bottom of the page add this line
-# * */# * * * /usr/local/bin/upgrade > /dev/null 2>&1
+#* */# * * * /usr/local/bin/upgrade > /dev/null 2>&1"
 # be sure to remove the first # and change the second one to a number 1-24.
 # the number you pick there will result in the script running every {number you choose} hours
 # personally I do every 12 hours cause I don't wanna get caught with an exploitable system
 # To have this script build the cron entry for you delete the # at the start of the next 4 lines
 
-# crontab -l
-# echo "* */12 * * * /usr/local/bin/upgrade > /dev/null 2>&1" >> crontab_new
-# crontab crontab_new
-# rm crontab_new
+ crontab -l
+ echo "* */12 * * * /usr/local/bin/upgrade > /dev/null 2>&1" >> crontab_new
+ crontab crontab_new
+ rm crontab_new

--- a/scripts/captainkyds_scripz/build&RunUpgradeCommand.txt
+++ b/scripts/captainkyds_scripz/build&RunUpgradeCommand.txt
@@ -1,0 +1,24 @@
+echo 'tput bold; tput setaf 5; echo "time to clean out old apt files and upgrade. Here we go"; tput sgr0' >> /usr/local/bin/upgrade
+echo 'tput bold; tput setaf 5; echo "Starting the cleaning cycle."; tput sgr0'  >> /usr/local/bin/upgrade
+echo 'apt clean -y' >> /usr/local/bin/upgrade
+echo 'apt autoremove -y' >> /usr/local/bin/upgrade
+echo 'tput bold; tput setaf 5; echo "updating and upgrading your distro" tput sgr0'  >> /usr/local/bin/upgrade
+echo 'apt update' >> /usr/local/bin/upgrade
+eco 'apt upgrade -y' >> /usr/local/bin/upgrade
+echo 'apt dist-upgrade -y' >> /usr/local/bin/upgrade
+echo 'tput bold; tput setaf 5; echo "the upgrade has been completed. Enjoy"; tput sgr0' >> /usr/local/bin/upgrade
+chmod +x /usr/local/bin/upgrade
+upgrade
+
+# this can now be run with "sudo upgrade" or added to your crontab via the command "sudo crontab -e"
+# select your favorite editor and at the bottom of the page add this line
+# * */# * * * /usr/local/bin/upgrade > /dev/null 2>&1
+# be sure to remove the first # and change the second one to a number 1-24.
+# the number you pick there will result in the script running every {number you choose} hours
+# personally I do every 12 hours cause I don't wanna get caught with an exploitable system
+# To have this script build the cron entry for you delete the # at the start of the next 4 lines
+
+# crontab -l
+# echo "* */12 * * * /usr/local/bin/upgrade > /dev/null 2>&1" >> crontab_new
+# crontab crontab_new
+# rm crontab_new

--- a/scripts/captainkyds_scripz/info.yml
+++ b/scripts/captainkyds_scripz/info.yml
@@ -1,0 +1,6 @@
+name: build&RunUpgradeCommand
+description: This script builds a command to clean unneeded apt files and upgrade your debian based system (Ubuntu, Debian or Kali). If you look at the last 3 lines it is also possible to have it set this command to run automatically ever 12 hours. If you want to change the time it might run in change the 12 to a number of your choice representing how many hours apart you want the script to run.
+version: 1.0.0
+license: Debian based (Ubuntu and Kali both)
+git: https://github.com/captainkyds/captainkyds_scripts4wsl.git
+distro: Debian (Ubuntu and


### PR DESCRIPTION
if edited it also has the potential to add it in as a cron job to run every 12 hours. IDK bout you, but I like to keep potential vulns in my nix servers/os to would have to be a zero day and want the holes patched asap. After running this command should one not wanna make it a cron job "sudo upgrade" runs apt clean, apt autoremove, apt update and then both the upgrade and dist-upgrade.